### PR TITLE
Create nuget-publish-core.yml

### DIFF
--- a/.github/workflows/nuget-publish-core.yml
+++ b/.github/workflows/nuget-publish-core.yml
@@ -23,4 +23,3 @@ jobs:
           PACKAGE_NAME: Chronos.Timer.Core
           # Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
           VERSION_FILE_PATH: ${{ github.workspace }}/src/Core/version.txt
-          # Regex pattern to extract version info in a capturing group

--- a/.github/workflows/nuget-publish-core.yml
+++ b/.github/workflows/nuget-publish-core.yml
@@ -1,0 +1,26 @@
+name: Publish Chronos.Timer.Core to Nuget.Org
+
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Restore, Build & Publish
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - name: Publish Core Package
+        uses: brandedoutcast/publish-nuget@v2.5.5
+        with:
+          # Filepath of the project to be packaged, relative to root of repository
+          PROJECT_FILE_PATH: ${{ github.workspace }}/src/Core/Chronos.Core.csproj
+          # NuGet package id, used for version detection & defaults to project name
+          PACKAGE_NAME: Chronos.Timer.Core
+          # Filepath with version info, relative to root of repository & defaults to PROJECT_FILE_PATH
+          VERSION_FILE_PATH: ${{ github.workspace }}/src/Core/version.txt
+          # Regex pattern to extract version info in a capturing group

--- a/Chronos.Tests.Mocks/Chronos.Timer.Tests.Mocks.csproj
+++ b/Chronos.Tests.Mocks/Chronos.Timer.Tests.Mocks.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Chronos.Tests.Mocks/Chronos.Timer.Tests.Mocks.csproj
+++ b/Chronos.Tests.Mocks/Chronos.Timer.Tests.Mocks.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\src\Core\Chronos.Core.csproj" />
+    <ProjectReference Include="..\src\Core\Chronos.Timer.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/chronos.sln
+++ b/chronos.sln
@@ -3,15 +3,15 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29926.136
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chronos.Core", "src\Core\Chronos.Core.csproj", "{64F5A808-2563-48A3-9DE8-120700972444}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chronos.Timer.Core", "src\Core\Chronos.Timer.Core.csproj", "{64F5A808-2563-48A3-9DE8-120700972444}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{89536306-B4ED-4E26-B38C-197E81F0A741}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Src", "Src", "{BD4BB505-47EF-4E57-9E4A-DBC40652DA5E}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chronos.Tests.Core", "tests\Core\Chronos.Tests.Core.csproj", "{6B34AC8B-0BAB-4282-8654-937B2FD08F23}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chronos.Timer.Tests.Mocks", "Chronos.Tests.Mocks\Chronos.Timer.Tests.Mocks.csproj", "{37B79322-A895-46EA-B686-6395740D0E2D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chronos.Tests.Mocks", "Chronos.Tests.Mocks\Chronos.Tests.Mocks.csproj", "{37B79322-A895-46EA-B686-6395740D0E2D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chronos.Timer.Tests.Core", "tests\Core\Chronos.Timer.Tests.Core.csproj", "{D00CED76-62F5-448F-973A-DA756CBF2A0E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,22 +23,21 @@ Global
 		{64F5A808-2563-48A3-9DE8-120700972444}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{64F5A808-2563-48A3-9DE8-120700972444}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{64F5A808-2563-48A3-9DE8-120700972444}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6B34AC8B-0BAB-4282-8654-937B2FD08F23}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6B34AC8B-0BAB-4282-8654-937B2FD08F23}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6B34AC8B-0BAB-4282-8654-937B2FD08F23}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6B34AC8B-0BAB-4282-8654-937B2FD08F23}.Release|Any CPU.Build.0 = Release|Any CPU
 		{37B79322-A895-46EA-B686-6395740D0E2D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{37B79322-A895-46EA-B686-6395740D0E2D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{37B79322-A895-46EA-B686-6395740D0E2D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{37B79322-A895-46EA-B686-6395740D0E2D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D00CED76-62F5-448F-973A-DA756CBF2A0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D00CED76-62F5-448F-973A-DA756CBF2A0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D00CED76-62F5-448F-973A-DA756CBF2A0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D00CED76-62F5-448F-973A-DA756CBF2A0E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{64F5A808-2563-48A3-9DE8-120700972444} = {BD4BB505-47EF-4E57-9E4A-DBC40652DA5E}
-		{6B34AC8B-0BAB-4282-8654-937B2FD08F23} = {89536306-B4ED-4E26-B38C-197E81F0A741}
-		{37B79322-A895-46EA-B686-6395740D0E2D} = {89536306-B4ED-4E26-B38C-197E81F0A741}
+		{D00CED76-62F5-448F-973A-DA756CBF2A0E} = {89536306-B4ED-4E26-B38C-197E81F0A741}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BB098665-CF57-4E73-B546-5299A41D4E3A}

--- a/src/Core/Chronos.Core.csproj
+++ b/src/Core/Chronos.Core.csproj
@@ -1,7 +1,0 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-
-</Project>

--- a/src/Core/Chronos.Timer.Core.csproj
+++ b/src/Core/Chronos.Timer.Core.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Version>0.0.1-alpha</Version>
+    <Authors>Danny Lewis, Mathieu St-Louis</Authors>
+    <Company />
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageProjectUrl></PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Scraniel/chronos</RepositoryUrl>
+    <PackageTags>Timer</PackageTags>
+    <Description>A utility library to help manage timed event callbacks.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/src/Core/Chronos.Timer.Core.csproj
+++ b/src/Core/Chronos.Timer.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Version>0.0.1-alpha</Version>
     <Authors>Danny Lewis, Mathieu St-Louis</Authors>
     <Company />

--- a/src/Core/version.txt
+++ b/src/Core/version.txt
@@ -1,0 +1,1 @@
+<Version>0.0.1-alpha</Version>

--- a/tests/Core/Chronos.Timer.Tests.Core.csproj
+++ b/tests/Core/Chronos.Timer.Tests.Core.csproj
@@ -7,14 +7,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\..\Chronos.Tests.Mocks\Chronos.Tests.Mocks.csproj" />
-    <ProjectReference Include="..\..\src\Core\Chronos.Core.csproj" />
+    <ProjectReference Include="..\..\Chronos.Tests.Mocks\Chronos.Timer.Tests.Mocks.csproj" />
+    <ProjectReference Include="..\..\src\Core\Chronos.Timer.Core.csproj" />
   </ItemGroup>
-
 </Project>

--- a/tests/Core/TimerUnitTests.cs
+++ b/tests/Core/TimerUnitTests.cs
@@ -1,9 +1,0 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-
-namespace tests.unit
-{
-    [TestClass]
-    class TimerUnitTests
-    {
-    }
-}

--- a/tests/Core/TimerUnitTests.cs
+++ b/tests/Core/TimerUnitTests.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace tests.unit
+{
+    [TestClass]
+    class TimerUnitTests
+    {
+    }
+}


### PR DESCRIPTION
- Create NuGet publishing build which will publish Chronos.Timer.Core to NuGet.org
-  Bump the .net standard to 2.1 in order to target [.net core 3.1](https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support)