### PR TITLE
Add build & package badges to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# chronos
+# Chronos Timers
+![](https://img.shields.io/nuget/v/Chronos.Timer.Core?style=flat-square&label=nuget) ![Windows-Gated](https://github.com/Scraniel/chronos/workflows/Windows-Gated/badge.svg?branch=main&event=push)
+
 A utility to help manage timed event callbacks.


### PR DESCRIPTION
# Issue #4 

- Add a NuGet badge to [Chronos.Timer.Core](https://www.nuget.org/packages/Chronos.Timer.Core/0.0.1-alpha)
- Add a build badge for windows gated build targeting main branch CI builds. 


### Preview

![image](https://user-images.githubusercontent.com/58675685/104106213-08f13000-5269-11eb-9fc8-f7ee3176aac8.png)

