### PR TITLE
Change type casting of ITimerFactory from ITimer to T

### DIFF
--- a/src/Core/TimerFactory/ITimerFactory.cs
+++ b/src/Core/TimerFactory/ITimerFactory.cs
@@ -14,8 +14,8 @@ namespace Chronos.Timer.Core
         /// </summary>
         /// <param name="timeTracker">The strategy which will provide the elapsed time.</param>
         /// <returns>A new ITimer.</returns>
-        ITimer CreateTimer<TTimer>(ITimeTrackingStrategy timeTracker = null)
-            where TTimer : ITimer;
+        T CreateTimer<T>(ITimeTrackingStrategy timeTracker = null)
+            where T : ITimer;
 
         /// <summary>
         /// Creates a timer for the task using the strategy given.
@@ -23,8 +23,8 @@ namespace Chronos.Timer.Core
         /// <param name="task">The task to perform.</param>
         /// <param name="timeTracker">The strategy which will provide the elapsed time.</param>
         /// <returns>A new ITimer.</returns>
-        ITimer CreateTimer<TTimer>(ITimerTask task, ITimeTrackingStrategy timeTracker = null)
-            where TTimer : ITimer;
+        T CreateTimer<T>(ITimerTask task, ITimeTrackingStrategy timeTracker = null)
+            where T : ITimer;
 
         /// <summary>
         /// Creates a timer for the list of tasks using the strategy given.
@@ -32,7 +32,7 @@ namespace Chronos.Timer.Core
         /// <param name="tasks">The list of tasks to perform.</param>
         /// <param name="timeTracker">The strategy which will provide the elapsed time.</param>
         /// <returns>A new ITimer</returns>
-        ITimer CreateTimer<TTimer>(List<ITimerTask> tasks, ITimeTrackingStrategy timeTracker = null)
-            where TTimer : ITimer;
+        T CreateTimer<T>(List<ITimerTask> tasks, ITimeTrackingStrategy timeTracker = null)
+            where T : ITimer;
     }
 }

--- a/src/Core/TimerFactory/TimerFactory.cs
+++ b/src/Core/TimerFactory/TimerFactory.cs
@@ -8,39 +8,39 @@ namespace Chronos.Timer.Core
         /// <summary>
         /// Creates a timer for the task using the strategy given.
         /// </summary>
-        /// <typeparam name="TTimer">The type of timer to create.</typeparam>
+        /// <typeparam name="T">The type of timer to create.</typeparam>
         /// <param name="timeTracker">The strategy which will provide the elapsed time.</param>
         /// <returns>A new ITimer.</returns>
-        public ITimer CreateTimer<TTimer>(ITimeTrackingStrategy timeTracker = null) where TTimer : ITimer
+        public T CreateTimer<T>(ITimeTrackingStrategy timeTracker = null) where T : ITimer
         {
-            return CreateTimer<TTimer>(new List<ITimerTask>(), timeTracker);
+            return CreateTimer<T>(new List<ITimerTask>(), timeTracker);
         }
 
         /// <summary>
         /// Creates a timer for the task using the strategy given.
         /// </summary>
-        /// <typeparam name="TTimer">The type of timer to create.</typeparam>
+        /// <typeparam name="T">The type of timer to create.</typeparam>
         /// <param name="task">The task to perform.</param>
         /// <param name="timeTracker">The strategy which will provide the elapsed time.</param>
         /// <returns>A new ITimer.</returns>
-        public ITimer CreateTimer<TTimer>(ITimerTask task, ITimeTrackingStrategy timeTracker = null) where TTimer : ITimer
+        public T CreateTimer<T>(ITimerTask task, ITimeTrackingStrategy timeTracker = null) where T : ITimer
         {
             if (task == null)
-                return CreateTimer<TTimer>(timeTracker);
+                return CreateTimer<T>(timeTracker);
 
-            return CreateTimer<TTimer>(new List<ITimerTask> { task }, timeTracker);
+            return CreateTimer<T>(new List<ITimerTask> { task }, timeTracker);
         }
 
         /// <summary>
         /// Creates a timer for the list of tasks using the strategy given.
         /// </summary>
-        /// <typeparam name="TTimer">The type of timer to create.</typeparam>
+        /// <typeparam name="T">The type of timer to create.</typeparam>
         /// <param name="tasks">The list of tasks to perform.</param>
         /// <param name="timeTracker">The strategy which will provide the elapsed time.</param>
         /// <returns>A new ITimer.</returns>
-        public ITimer CreateTimer<TTimer>(List<ITimerTask> tasks, ITimeTrackingStrategy timeTracker = null) where TTimer : ITimer
+        public T CreateTimer<T>(List<ITimerTask> tasks, ITimeTrackingStrategy timeTracker = null) where T : ITimer
         {
-            TTimer timer = (TTimer)Activator.CreateInstance(typeof(TTimer));
+            T timer = (T)Activator.CreateInstance(typeof(T));
             timer.Initialize(timeTracker, tasks);
             return timer;
         }

--- a/tests/Core/TimerFactoryUnitTests.cs
+++ b/tests/Core/TimerFactoryUnitTests.cs
@@ -18,7 +18,7 @@ namespace Chronos.Timer.Tests.Core
         [TestMethod]
         public void CreateTimer_TimeTrackingIsNull_CreatesValidNewTimer()
         {
-            TestTimer timer = _target.CreateTimer<TestTimer>() as TestTimer;
+            TestTimer timer = _target.CreateTimer<TestTimer>();
 
             AssertValidCreation(timer);
             Assert.IsNull(timer.TimeTrackingStrategy);
@@ -37,7 +37,7 @@ namespace Chronos.Timer.Tests.Core
         [TestMethod]
         public void CreateTimer_SystemTimeTracking_CreatesValidNewTimer()
         {
-            TestTimer timer = _target.CreateTimer<TestTimer>(new SystemTimeTracker()) as TestTimer;
+            TestTimer timer = _target.CreateTimer<TestTimer>(new SystemTimeTracker());
 
             AssertValidCreation(timer);
             Assert.IsInstanceOfType(timer.TimeTrackingStrategy, typeof(SystemTimeTracker));
@@ -46,7 +46,7 @@ namespace Chronos.Timer.Tests.Core
         [TestMethod]
         public void CreateTimer_NullTimerTask_CreatesValidNewTimer()
         {
-            TestTimer timer = _target.CreateTimer<TestTimer>(new SystemTimeTracker()) as TestTimer;
+            TestTimer timer = _target.CreateTimer<TestTimer>(new SystemTimeTracker());
 
             AssertValidCreation(timer);
             Assert.AreEqual(0, timer.Tasks.Count);
@@ -57,7 +57,7 @@ namespace Chronos.Timer.Tests.Core
         {
             TestTimer timer = _target.CreateTimer<TestTimer>(
                 new TimerTask(() => { }, TimeSpan.FromSeconds(1)),
-                new SystemTimeTracker()) as TestTimer;
+                new SystemTimeTracker());
 
             AssertValidCreation(timer);
             Assert.AreEqual(1, timer.Tasks.Count);
@@ -74,7 +74,7 @@ namespace Chronos.Timer.Tests.Core
 
             TestTimer timer = _target.CreateTimer<TestTimer>(
                 tasks,
-                new SystemTimeTracker()) as TestTimer;
+                new SystemTimeTracker());
 
             AssertValidCreation(timer);
             Assert.AreEqual(2, timer.Tasks.Count);


### PR DESCRIPTION
The ITimerFactory returned an ITimer which forced users to cast their timer whenever creating new timers through the factory. 
This changes the return type to the generic type given when creating a timer.


### Before
` BasicTimer myTimer = _factory.CreateTimer<BasicTimer>(TimeSpan.FromSeconds(1), () => {}) as BasicTimer;`

### After
` BasicTimer myTimer = _factory.CreateTimer<BasicTimer>(TimeSpan.FromSeconds(1), () => {});`