### PR TITLE
Adding a concrete example / E2E test scenario for basic timer

### DIFF
--- a/Chronos.Timer.Examples/BasicTimerExample.cs
+++ b/Chronos.Timer.Examples/BasicTimerExample.cs
@@ -9,6 +9,15 @@ namespace Chronos.Timer.Examples
 {
     class BasicTimerExample
     {
+
+        private static int _endLine;
+        private static int _startLine = 2;
+        private static string _lineBreak = "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=";
+        private static object _writeLock = new object();
+
+        private static long _totalDelay = 0;
+        private static int _executionCount = 0;
+
         static void Main(string[] args)
         {
             int numRepeats = 10; 
@@ -68,14 +77,6 @@ namespace Chronos.Timer.Examples
             Console.ReadKey();
         }
 
-        private static int _endLine;
-        private static int _startLine = 2;
-        private static string _lineBreak = "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=";
-        private static object _writeLock = new object();
-
-        private static long _totalDelay = 0;
-        private static int _executionCount = 0;
-
         private static void PrintEndLine()
         {
             lock (_writeLock)
@@ -87,7 +88,7 @@ namespace Chronos.Timer.Examples
             }
         }
 
-        static async Task PrintStats()
+        private static async Task PrintStats()
         {
             int refreshRateMs = 500;
 

--- a/Chronos.Timer.Examples/BasicTimerExample.cs
+++ b/Chronos.Timer.Examples/BasicTimerExample.cs
@@ -12,7 +12,7 @@ namespace Chronos.Timer.Examples
         static void Main(string[] args)
         {
             int numRepeats = 10; 
-            long eventPeriodMs = 200;
+            long eventPeriodMs = 1000;
             long idealTimeMs = 0;
             _endLine = numRepeats + _startLine + 1;
 

--- a/Chronos.Timer.Examples/BasicTimerExample.cs
+++ b/Chronos.Timer.Examples/BasicTimerExample.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Chronos.Timer.Core;
+
+namespace Chronos.Timer.Examples
+{
+    class BasicTimerExample
+    {
+        static void Main(string[] args)
+        {
+            int numRepeats = 10; 
+            long eventPeriodMs = 200;
+            long idealTimeMs = 0;
+            _endLine = numRepeats + _startLine + 1;
+
+            Console.WriteLine(_lineBreak);
+            Console.WriteLine(string.Format("This example should trigger an event every {0} ms, repeating {1} times.", eventPeriodMs, numRepeats));
+            Console.WriteLine(_lineBreak);
+
+            // The ITimerRuntime maintains a list of your timers and ensures they get run at the correct times for the correct duration.
+            //
+            ITimerRuntime timerRuntime = new TimerRuntime();
+
+            Stopwatch watch = new Stopwatch();
+            watch.Start();
+
+            // This is the action we want the timer to execute: it simply logs how close we were to ideal timings.
+            //
+            Action logIdealTime = () =>
+            {
+                long currentTime = watch.ElapsedMilliseconds;
+                long delta = Math.Abs(Interlocked.Add(ref idealTimeMs, eventPeriodMs) - currentTime);
+                Interlocked.Add(ref _totalDelay, delta);
+                long executions = Interlocked.Increment(ref _executionCount);
+
+                lock (_writeLock)
+                {
+                    Console.SetCursorPosition(0, _startLine + _executionCount);
+                    Console.WriteLine(string.Format("Execution #{0} after {1} ms ({2}ms off ideal time)", executions, currentTime, delta));
+                }
+            };
+
+            // TODO: fix bug in runtime. 
+            //
+            // If all you want to do is get events running periodically, all that's required is a registration.
+            //
+            // timerRuntime.Register<BasicTimer>(TimeSpan.FromMilliseconds(eventPeriodMs), numRepeats, logIdealTime);
+
+            // For the more advanced use-case:
+            // - ITimerAction wraps your regular action, encapsulating timer info alongside the delegate.
+            // - ITimerFactory tells the runtime what type of ITimer to create
+            // - ITimeTrackingStrategy tells the runtime how to measure the amount of time that passes
+            //     - For example, SystemTimeTrackingStrategy simply uses the system clock, whereas a "TurnBasedTrackingStrategy" might use discrete turns
+            //
+            ITimerAction action = new BasicTimerAction(logIdealTime, TimeSpan.FromMilliseconds(eventPeriodMs), numRepeats);
+            ITimerFactory factory = new TimerFactory();
+            ITimeTrackingStrategy strategy = new SystemTimeTrackingStrategy();
+            timerRuntime.Register(factory.CreateTimer<BasicTimer>(action, strategy));
+
+            PrintEndLine();
+
+            // Run task async, allow break early if key is pressed.
+            //
+            _ = PrintStats();
+            Console.ReadKey();
+        }
+
+        private static int _endLine;
+        private static int _startLine = 2;
+        private static string _lineBreak = "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=";
+        private static object _writeLock = new object();
+
+        private static long _totalDelay = 0;
+        private static int _executionCount = 0;
+
+        private static void PrintEndLine()
+        {
+            lock (_writeLock)
+            {
+                Console.SetCursorPosition(0, _endLine);
+                Console.WriteLine(_lineBreak);
+                Console.WriteLine("\n\nPress any key to Exit.");
+                Console.SetCursorPosition(0, _startLine);
+            }
+        }
+
+        static async Task PrintStats()
+        {
+            int refreshRateMs = 500;
+
+            await Task.Run(() =>
+            {
+                while (true)
+                {
+                    lock (_writeLock)
+                    {
+                        int executions = _executionCount == 0 ? 1 : _executionCount;
+                        Console.SetCursorPosition(0, _endLine + 1);
+                        Console.WriteLine(string.Format("TOTAL DELAY: {0} ms         AVERAGE DELAY: {1} ms         ", _totalDelay, _totalDelay / executions));
+                    }
+
+                    Thread.Sleep(refreshRateMs);
+                }
+            });
+        }
+    }
+}

--- a/Chronos.Timer.Examples/Chronos.Timer.Examples.csproj
+++ b/Chronos.Timer.Examples/Chronos.Timer.Examples.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Core\Chronos.Timer.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/chronos.sln
+++ b/chronos.sln
@@ -13,6 +13,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chronos.Timer.Mocks", "src\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Chronos.Timer.Tests.Core", "tests\Core\Chronos.Timer.Tests.Core.csproj", "{FF595757-9B62-4A42-A258-43335D509481}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{B1CC95D6-22BD-4B64-A526-7A5F884D560B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chronos.Timer.Examples", "Chronos.Timer.Examples\Chronos.Timer.Examples.csproj", "{C872F72B-7220-4354-8C24-4C6F84BD8BAD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,6 +35,10 @@ Global
 		{FF595757-9B62-4A42-A258-43335D509481}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FF595757-9B62-4A42-A258-43335D509481}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FF595757-9B62-4A42-A258-43335D509481}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C872F72B-7220-4354-8C24-4C6F84BD8BAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C872F72B-7220-4354-8C24-4C6F84BD8BAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C872F72B-7220-4354-8C24-4C6F84BD8BAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C872F72B-7220-4354-8C24-4C6F84BD8BAD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -39,6 +47,7 @@ Global
 		{64F5A808-2563-48A3-9DE8-120700972444} = {BD4BB505-47EF-4E57-9E4A-DBC40652DA5E}
 		{1DB51DCF-C07B-469E-B531-67107314BE48} = {BD4BB505-47EF-4E57-9E4A-DBC40652DA5E}
 		{FF595757-9B62-4A42-A258-43335D509481} = {89536306-B4ED-4E26-B38C-197E81F0A741}
+		{C872F72B-7220-4354-8C24-4C6F84BD8BAD} = {B1CC95D6-22BD-4B64-A526-7A5F884D560B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BB098665-CF57-4E73-B546-5299A41D4E3A}

--- a/src/Core/TimeTrackingStrategy/SystemTimeTrackingStrategy.cs
+++ b/src/Core/TimeTrackingStrategy/SystemTimeTrackingStrategy.cs
@@ -73,7 +73,9 @@ namespace Chronos.Timer.Core
                 return;
             }
 
-            _elapsed += DateTime.Now - _lastUpdate;
+            DateTime now = DateTime.Now;
+            _elapsed += now - _lastUpdate;
+            _lastUpdate = now;
         }
     }
 }

--- a/src/Core/Timer/BasicTimer.cs
+++ b/src/Core/Timer/BasicTimer.cs
@@ -51,12 +51,10 @@ namespace Chronos.Timer.Core
             }
 
             _timeTrackingStrategy.Update();
-            TimeSpan previousElapsedTime = TotalElapsedTime;
             TotalElapsedTime = _timeTrackingStrategy.GetTimeElapsed();
-            TimeSpan stepTime = TotalElapsedTime - previousElapsedTime;
 
             TimeSpan nextTime = _timerTasks[0].Key;
-            TimeLeft = MaxTimespan(TimeSpan.Zero, nextTime - _epsilon - stepTime);
+            TimeLeft = MaxTimespan(TimeSpan.Zero, nextTime - _epsilon - TotalElapsedTime);
 
             if (TimeLeft > TimeSpan.Zero)
             {

--- a/src/Core/Timer/ITimer.cs
+++ b/src/Core/Timer/ITimer.cs
@@ -12,7 +12,7 @@ namespace Chronos.Timer.Core
         /// <summary>
         /// The elapsed time since the timer was initially started.
         /// </summary>
-        public TimeSpan ElapsedTime { get; }
+        public TimeSpan TotalElapsedTime { get; }
 
         /// <summary>
         /// The time left before the execution of the next action.

--- a/src/Core/TimerAction/BasicTimerAction.cs
+++ b/src/Core/TimerAction/BasicTimerAction.cs
@@ -47,6 +47,7 @@ namespace Chronos.Timer.Core
             _task = task;
             _finished = false;
             TimesToExecute = numTimesToRun;
+            Period = period;
         }
         public async Task ExecuteAsync()
         {

--- a/src/Mocks/MockTimer.cs
+++ b/src/Mocks/MockTimer.cs
@@ -7,7 +7,7 @@ namespace Chronos.Timer.Mocks
 {
     public class MockTimer : ITimer
     {
-        public TimeSpan ElapsedTime { get; set; }
+        public TimeSpan TotalElapsedTime { get; set; }
 
         public TimeSpan TimeLeft { get; set; }
 
@@ -49,7 +49,7 @@ namespace Chronos.Timer.Mocks
             return new MockTimer
             {
                 Id = Id,
-                ElapsedTime = ElapsedTime,
+                TotalElapsedTime = TotalElapsedTime,
                 TimeLeft = TimeLeft,
                 OnClear = (Action)OnClear?.Clone(),
                 OnInitialize = (Action)OnInitialize?.Clone(),

--- a/tests/Core/BasicTimerUnitTests.cs
+++ b/tests/Core/BasicTimerUnitTests.cs
@@ -34,7 +34,7 @@ namespace Chronos.Timer.Tests.Core
             ITimer timer = GetBasicTimerAndInitialize(new List<Action> { _noOpAction });
             timer.Pause();
             timer.UpdateAsync().Wait();
-            Assert.AreEqual(TimeSpan.Zero, timer.ElapsedTime);
+            Assert.AreEqual(TimeSpan.Zero, timer.TotalElapsedTime);
         }
 
         [TestMethod]
@@ -43,10 +43,10 @@ namespace Chronos.Timer.Tests.Core
             ITimer timer = GetBasicTimerAndInitialize(new List<Action> { _noOpAction });
             timer.Pause();
             timer.UpdateAsync().Wait();
-            Assert.AreEqual(TimeSpan.Zero, timer.ElapsedTime);
+            Assert.AreEqual(TimeSpan.Zero, timer.TotalElapsedTime);
             timer.Unpause();
             timer.UpdateAsync().Wait();
-            Assert.AreEqual(_timeStep, timer.ElapsedTime);
+            Assert.AreEqual(_timeStep, timer.TotalElapsedTime);
         }
 
         [TestMethod]
@@ -73,10 +73,10 @@ namespace Chronos.Timer.Tests.Core
             {
                 timer.UpdateAsync().Wait();
             }
-            Assert.IsTrue(timer.ElapsedTime > TimeSpan.Zero);
+            Assert.IsTrue(timer.TotalElapsedTime > TimeSpan.Zero);
 
             timer.Clear();
-            Assert.AreEqual(TimeSpan.Zero, timer.ElapsedTime);
+            Assert.AreEqual(TimeSpan.Zero, timer.TotalElapsedTime);
         }
 
         [TestMethod]
@@ -88,7 +88,7 @@ namespace Chronos.Timer.Tests.Core
             {
                 timer.UpdateAsync().Wait();
             }
-            Assert.AreEqual(_timeStep * numUpdates, timer.ElapsedTime);
+            Assert.AreEqual(_timeStep * numUpdates, timer.TotalElapsedTime);
         }
 
         [TestMethod]

--- a/tests/Core/TimerFactoryUnitTests.cs
+++ b/tests/Core/TimerFactoryUnitTests.cs
@@ -84,7 +84,7 @@ namespace Chronos.Timer.Tests.Core
         // TODO Replace with mock implementation
         private class TestTimer : ITimer
         {
-            public TimeSpan ElapsedTime => throw new NotImplementedException();
+            public TimeSpan TotalElapsedTime => throw new NotImplementedException();
 
             public TimeSpan TimeLeft => throw new NotImplementedException();
 


### PR DESCRIPTION
This update adds `BasicTimerExample`, a simple example that just prints out how close we are to hitting ideal times when using the `BasicTimer` with `SystemTimeTrackingStrategy`.