### PR TITLE
Add TimerProxy which enables interacting with the runtime.

### DIFF
--- a/src/Core/Runtime/ITimerRuntime.cs
+++ b/src/Core/Runtime/ITimerRuntime.cs
@@ -21,7 +21,7 @@ namespace Chronos.Timer.Core
         /// <param name="actionToExecute">The action to execute.</param>
         /// <param name="numberOfExecution">The number of time an action should be executed.</param>
         /// <returns>A registered timer.</returns>
-        TimerInfo Register<T>(TimeSpan period, int numberOfExecution, Action actionToExecute)
+        TimerProxy Register<T>(TimeSpan period, int numberOfExecution, Action actionToExecute)
             where T : ITimer;
 
         /// <summary>
@@ -30,14 +30,14 @@ namespace Chronos.Timer.Core
         /// <typeparam name="T">The timer type to register.</typeparam>
         /// <param name="timer">The timer to register.</param>
         /// <returns>The registered timer.</returns>
-        TimerInfo Register<T>(T timer)
+        TimerProxy Register<T>(T timer)
             where T : ITimer;
 
         /// <summary>
         /// Unregister a timer from the timer runtime. This will ensure that the timer is not updated/executed anymore.
         /// </summary>
         /// <param name="timer">The timer to unregister.</param>
-        void Unregister(TimerInfo timer);
+        void Unregister(TimerProxy timer);
 
         /// <summary>
         /// Unregister a timer from the timer runtime. This will ensure that the timer is not updated/executed anymore.
@@ -50,12 +50,12 @@ namespace Chronos.Timer.Core
         /// </summary>
         /// <param name="timerId">The id of the timer registered with this runtime.</param>
         /// <returns>Returns the timer with the given id.</returns>
-        TimerInfo GetTimer(Guid timerId);
+        TimerProxy GetTimer(Guid timerId);
 
         /// <summary>
         /// Gets all of the timers currently registered to this runtime.
         /// </summary>
         /// <returns>A <see cref="IEnumerable{T}"/> of all timers registered with this runtime.</returns>
-        IEnumerable<TimerInfo> GetTimers();
+        IEnumerable<TimerProxy> GetTimers();
     }
 }

--- a/src/Core/Runtime/ITimerRuntime.cs
+++ b/src/Core/Runtime/ITimerRuntime.cs
@@ -21,7 +21,7 @@ namespace Chronos.Timer.Core
         /// <param name="actionToExecute">The action to execute.</param>
         /// <param name="numberOfExecution">The number of time an action should be executed.</param>
         /// <returns>A registered timer.</returns>
-        T Register<T>(TimeSpan period, int numberOfExecution, Action actionToExecute)
+        TimerInfo Register<T>(TimeSpan period, int numberOfExecution, Action actionToExecute)
             where T : ITimer;
 
         /// <summary>
@@ -30,14 +30,14 @@ namespace Chronos.Timer.Core
         /// <typeparam name="T">The timer type to register.</typeparam>
         /// <param name="timer">The timer to register.</param>
         /// <returns>The registered timer.</returns>
-        T Register<T>(T timer)
+        TimerInfo Register<T>(T timer)
             where T : ITimer;
 
         /// <summary>
         /// Unregister a timer from the timer runtime. This will ensure that the timer is not updated/executed anymore.
         /// </summary>
         /// <param name="timer">The timer to unregister.</param>
-        void Unregister(ITimer timer);
+        void Unregister(TimerInfo timer);
 
         /// <summary>
         /// Unregister a timer from the timer runtime. This will ensure that the timer is not updated/executed anymore.
@@ -50,12 +50,12 @@ namespace Chronos.Timer.Core
         /// </summary>
         /// <param name="timerId">The id of the timer registered with this runtime.</param>
         /// <returns>Returns the timer with the given id.</returns>
-        ITimer GetTimer(Guid timerId);
+        TimerInfo GetTimer(Guid timerId);
 
         /// <summary>
         /// Gets all of the timers currently registered to this runtime.
         /// </summary>
         /// <returns>A <see cref="IEnumerable{T}"/> of all timers registered with this runtime.</returns>
-        IEnumerable<ITimer> GetTimers();
+        IEnumerable<TimerInfo> GetTimers();
     }
 }

--- a/src/Core/Runtime/TimerRuntime.cs
+++ b/src/Core/Runtime/TimerRuntime.cs
@@ -69,7 +69,7 @@ namespace Chronos.Timer.Core
         /// <param name="numberOfExecution">The number of time an action should be executed.</param>
         /// <returns>A registered timer.</returns>
         /// <returns></returns>
-        public TimerInfo Register<T>(TimeSpan period, int numberOfExecution, Action actionToExecute) where T : ITimer
+        public TimerProxy Register<T>(TimeSpan period, int numberOfExecution, Action actionToExecute) where T : ITimer
             => Register(_timerFactory
                     .CreateTimer<T>(new BasicTimerAction(actionToExecute, period, numberOfExecution)));
 
@@ -79,7 +79,7 @@ namespace Chronos.Timer.Core
         /// <typeparam name="T">The timer type to register.</typeparam>
         /// <param name="timer">The timer to register.</param>
         /// <returns>The registered timer.</returns>
-        public TimerInfo Register<T>(T timer) where T : ITimer
+        public TimerProxy Register<T>(T timer) where T : ITimer
         {
             if (!_timers.ContainsKey(timer.Id))
             {
@@ -92,7 +92,7 @@ namespace Chronos.Timer.Core
                 StartUpdate();
             }
 
-            return new TimerInfo(timer);
+            return new TimerProxy(timer);
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Chronos.Timer.Core
         /// </remarks>
         /// <exception cref="ArgumentNullException">Thrown if the timer passed in is null.</exception>
         /// <param name="timerInfo">The timer to unregister.</param>
-        public void Unregister(TimerInfo timerInfo)
+        public void Unregister(TimerProxy timerInfo)
         {
             timerInfo = timerInfo ?? throw new ArgumentNullException(nameof(timerInfo));
             Unregister(timerInfo.Id);
@@ -135,10 +135,10 @@ namespace Chronos.Timer.Core
         /// </summary>
         /// <param name="timerId">The id of the timer registered with this runtime.</param>
         /// <returns>Returns the timer with the given id, or null if the timer isn't found.</returns>
-        public TimerInfo GetTimer(Guid timerId)
+        public TimerProxy GetTimer(Guid timerId)
         {
             if (_timers.TryGetValue(timerId, out ITimer timer))
-                return new TimerInfo(timer);
+                return new TimerProxy(timer);
             return null;
         }
 
@@ -146,10 +146,10 @@ namespace Chronos.Timer.Core
         /// Gets all of the timers currently registered to this runtime.
         /// </summary>
         /// <returns>A <see cref="IEnumerable{T}"/> of all timers registered with this runtime.</returns>
-        public IEnumerable<TimerInfo> GetTimers()
+        public IEnumerable<TimerProxy> GetTimers()
             => _timers
                     .Values
-                    .Select(timer => new TimerInfo(timer));
+                    .Select(timer => new TimerProxy(timer));
 
         /// <summary>
         /// Starts the update thread.

--- a/src/Core/Runtime/TimerRuntime.cs
+++ b/src/Core/Runtime/TimerRuntime.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -68,7 +69,7 @@ namespace Chronos.Timer.Core
         /// <param name="numberOfExecution">The number of time an action should be executed.</param>
         /// <returns>A registered timer.</returns>
         /// <returns></returns>
-        public T Register<T>(TimeSpan period, int numberOfExecution, Action actionToExecute) where T : ITimer
+        public TimerInfo Register<T>(TimeSpan period, int numberOfExecution, Action actionToExecute) where T : ITimer
             => Register(_timerFactory
                     .CreateTimer<T>(new BasicTimerAction(actionToExecute, period, numberOfExecution)));
 
@@ -78,7 +79,7 @@ namespace Chronos.Timer.Core
         /// <typeparam name="T">The timer type to register.</typeparam>
         /// <param name="timer">The timer to register.</param>
         /// <returns>The registered timer.</returns>
-        public T Register<T>(T timer) where T : ITimer
+        public TimerInfo Register<T>(T timer) where T : ITimer
         {
             if (!_timers.ContainsKey(timer.Id))
             {
@@ -91,7 +92,7 @@ namespace Chronos.Timer.Core
                 StartUpdate();
             }
 
-            return timer;
+            return new TimerInfo(timer);
         }
 
         /// <summary>
@@ -101,11 +102,11 @@ namespace Chronos.Timer.Core
         /// Unregistering a timer which is not currently registered with the runtime will result in a no-op.
         /// </remarks>
         /// <exception cref="ArgumentNullException">Thrown if the timer passed in is null.</exception>
-        /// <param name="timer">The timer to unregister.</param>
-        public void Unregister(ITimer timer)
+        /// <param name="timerInfo">The timer to unregister.</param>
+        public void Unregister(TimerInfo timerInfo)
         {
-            timer = timer ?? throw new ArgumentNullException(nameof(timer));
-            Unregister(timer.Id);
+            timerInfo = timerInfo ?? throw new ArgumentNullException(nameof(timerInfo));
+            Unregister(timerInfo.Id);
         }
 
         /// <summary>
@@ -134,10 +135,10 @@ namespace Chronos.Timer.Core
         /// </summary>
         /// <param name="timerId">The id of the timer registered with this runtime.</param>
         /// <returns>Returns the timer with the given id, or null if the timer isn't found.</returns>
-        public ITimer GetTimer(Guid timerId)
+        public TimerInfo GetTimer(Guid timerId)
         {
             if (_timers.TryGetValue(timerId, out ITimer timer))
-                return timer;
+                return new TimerInfo(timer);
             return null;
         }
 
@@ -145,8 +146,10 @@ namespace Chronos.Timer.Core
         /// Gets all of the timers currently registered to this runtime.
         /// </summary>
         /// <returns>A <see cref="IEnumerable{T}"/> of all timers registered with this runtime.</returns>
-        public IEnumerable<ITimer> GetTimers()
-            => _timers.Values;
+        public IEnumerable<TimerInfo> GetTimers()
+            => _timers
+                    .Values
+                    .Select(timer => new TimerInfo(timer));
 
         /// <summary>
         /// Starts the update thread.

--- a/src/Core/TimerInfo/TimerInfo.cs
+++ b/src/Core/TimerInfo/TimerInfo.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 
-namespace Chronos.Timer.Core.TimerInfo
+namespace Chronos.Timer.Core
 {
+    /// <summary>
+    /// Encapsulates timer-related information.
+    /// </summary>
     public class TimerInfo
     {
         private ITimer _timer;
-        public TimerInfo(ITimer timer)
-        {
-            _timer = timer;
-        }
 
         /// <summary>
         /// The elapsed time since the timer was initially started.
@@ -34,10 +33,14 @@ namespace Chronos.Timer.Core.TimerInfo
         /// <summary>
         /// The Timer's UID used to register/unregister with the Chronos timer runtime.
         /// </summary>
-        public Guid Id { get
-            {
-                return _timer.Id;
-            }
+        public Guid Id
+        {
+            get => _timer.Id;
+        }
+
+        public TimerInfo(ITimer timer)
+        {
+            _timer = timer;
         }
 
         /// <summary>

--- a/src/Core/TimerInfo/TimerInfo.cs
+++ b/src/Core/TimerInfo/TimerInfo.cs
@@ -1,0 +1,61 @@
+﻿using System;
+
+namespace Chronos.Timer.Core.TimerInfo
+{
+    public class TimerInfo
+    {
+        private ITimer _timer;
+        public TimerInfo(ITimer timer)
+        {
+            _timer = timer;
+        }
+
+        /// <summary>
+        /// The elapsed time since the timer was initially started.
+        /// </summary>
+        public TimeSpan ElapsedTime
+        {
+            get => _timer.ElapsedTime;
+        }
+
+        /// <summary>
+        /// The time left before the execution of the next action.
+        /// </summary>
+        public TimeSpan TimeLeft
+        {
+            get => _timer.TimeLeft;
+        }
+
+        public bool IsPaused
+        {
+            get => _timer.IsPaused();
+        }
+
+        /// <summary>
+        /// The Timer's UID used to register/unregister with the Chronos timer runtime.
+        /// </summary>
+        public Guid Id { get
+            {
+                return _timer.Id;
+            }
+        }
+
+        /// <summary>
+        /// Unpauses the timer and restarts tracking time.
+        /// </summary>
+        public void Unpause()
+            => _timer.Unpause();
+
+        /// <summary>
+        /// Pauses the timer and stops tracking time.
+        /// </summary>
+        public void Pause()
+            => _timer.Pause();
+
+        /// <summary>
+        /// Wipes the elapsed time stored in the tracker. Does not pause the timer.
+        /// </summary>
+        public void Clear()
+            => _timer.Clear();
+    }
+}

--- a/src/Core/TimerProxy/TimerProxy.cs
+++ b/src/Core/TimerProxy/TimerProxy.cs
@@ -3,9 +3,9 @@
 namespace Chronos.Timer.Core
 {
     /// <summary>
-    /// Encapsulates timer-related information.
+    /// Encapsulates timer-related method and information.
     /// </summary>
-    public class TimerInfo
+    public class TimerProxy
     {
         private ITimer _timer;
 
@@ -38,7 +38,7 @@ namespace Chronos.Timer.Core
             get => _timer.Id;
         }
 
-        public TimerInfo(ITimer timer)
+        public TimerProxy(ITimer timer)
         {
             _timer = timer;
         }

--- a/src/Core/TimerProxy/TimerProxy.cs
+++ b/src/Core/TimerProxy/TimerProxy.cs
@@ -12,9 +12,9 @@ namespace Chronos.Timer.Core
         /// <summary>
         /// The elapsed time since the timer was initially started.
         /// </summary>
-        public TimeSpan ElapsedTime
+        public TimeSpan TotalElapsedTime
         {
-            get => _timer.ElapsedTime;
+            get => _timer.TotalElapsedTime;
         }
 
         /// <summary>

--- a/tests/Core/TimerRuntimeUnitTests.cs
+++ b/tests/Core/TimerRuntimeUnitTests.cs
@@ -27,7 +27,7 @@ namespace Chronos.Timer.Tests.Core
         [TestMethod]
         public void Register_CreatesTimerSuccessfully_TimerIsRegistered()
         {
-            TimerInfo timer = _target.Register<MockTimer>(TimeSpan.FromSeconds(1), 1, () => { });
+            TimerProxy timer = _target.Register<MockTimer>(TimeSpan.FromSeconds(1), 1, () => { });
             Assert.IsNotNull(timer);
             Assert.IsNotNull(_target.GetTimer(timer.Id));
         }
@@ -61,15 +61,15 @@ namespace Chronos.Timer.Tests.Core
             MockTimer timer = _mockTimerFactory.CreateTimer<MockTimer>(
                 new BasicTimerAction(() => { }, TimeSpan.FromSeconds(1), 1));
 
-            TimerInfo timer1 = _target.Register(timer);
+            TimerProxy timer1 = _target.Register(timer);
             Assert.IsNotNull(timer);
             
-            TimerInfo timer2 = _target.Register(timer);
+            TimerProxy timer2 = _target.Register(timer);
             
             Assert.IsNotNull(timer2);
             Assert.AreEqual(timer.Id, timer2.Id);
 
-            List<TimerInfo> timers = _target.GetTimers().ToList();
+            List<TimerProxy> timers = _target.GetTimers().ToList();
             Assert.AreEqual(1, timers.Count);
         }
 
@@ -104,7 +104,7 @@ namespace Chronos.Timer.Tests.Core
         [TestMethod]
         public void GetTimer_TimerIsRegistered_ReturnsTimer()
         {
-            TimerInfo timer = _target.Register<MockTimer>(TimeSpan.FromSeconds(1), 1, () => { });
+            TimerProxy timer = _target.Register<MockTimer>(TimeSpan.FromSeconds(1), 1, () => { });
 
             Assert.IsNotNull(_target.GetTimer(timer.Id));
         }
@@ -112,14 +112,14 @@ namespace Chronos.Timer.Tests.Core
         [TestMethod]
         public void GetTimer_TimerIsNotRegistered_ReturnsNull()
         {
-            TimerInfo timer = _target.GetTimer(Guid.NewGuid());
+            TimerProxy timer = _target.GetTimer(Guid.NewGuid());
             Assert.IsNull(timer);
         }
 
         [TestMethod]
         public void ListTimers_NoTimers_ReturnsEmptyList()
         {
-            List<TimerInfo> timers = _target
+            List<TimerProxy> timers = _target
                 .GetTimers()
                 .ToList();
 
@@ -129,9 +129,9 @@ namespace Chronos.Timer.Tests.Core
         [TestMethod]
         public void ListTimers_ContainsSingleTimer_SingleElement()
         {
-            TimerInfo timer = _target.Register<MockTimer>(TimeSpan.FromSeconds(1), 1, () => { });
+            TimerProxy timer = _target.Register<MockTimer>(TimeSpan.FromSeconds(1), 1, () => { });
 
-            List<TimerInfo> timers = _target
+            List<TimerProxy> timers = _target
                 .GetTimers()
                 .ToList();
 
@@ -142,7 +142,7 @@ namespace Chronos.Timer.Tests.Core
         [TestMethod]
         public void RegisterUnregisterList_ReturnsExpectedTimers()
         {
-            List<TimerInfo> timers = new List<TimerInfo>();
+            List<TimerProxy> timers = new List<TimerProxy>();
 
             int totalTimers = 10;
 
@@ -156,7 +156,7 @@ namespace Chronos.Timer.Tests.Core
                 _target.Unregister(timers[i].Id);
             }
 
-            List<TimerInfo> runtimeTimers = _target.GetTimers().ToList();
+            List<TimerProxy> runtimeTimers = _target.GetTimers().ToList();
             
             Assert.AreEqual(totalTimers - totalTimers / 2, runtimeTimers.Count);
             

--- a/tests/Core/TimerRuntimeUnitTests.cs
+++ b/tests/Core/TimerRuntimeUnitTests.cs
@@ -27,7 +27,7 @@ namespace Chronos.Timer.Tests.Core
         [TestMethod]
         public void Register_CreatesTimerSuccessfully_TimerIsRegistered()
         {
-            ITimer timer = _target.Register<MockTimer>(TimeSpan.FromSeconds(1), 1, () => { });
+            TimerInfo timer = _target.Register<MockTimer>(TimeSpan.FromSeconds(1), 1, () => { });
             Assert.IsNotNull(timer);
             Assert.IsNotNull(_target.GetTimer(timer.Id));
         }
@@ -58,15 +58,18 @@ namespace Chronos.Timer.Tests.Core
         [TestMethod]
         public void Register_RegisterSameTimerTwice_SingleRegistration()
         {
-            ITimer timer1 = _target.Register<MockTimer>(TimeSpan.FromSeconds(1), 1, () => { });
-            Assert.IsNotNull(timer1);
+            MockTimer timer = _mockTimerFactory.CreateTimer<MockTimer>(
+                new BasicTimerAction(() => { }, TimeSpan.FromSeconds(1), 1));
+
+            TimerInfo timer1 = _target.Register(timer);
+            Assert.IsNotNull(timer);
             
-            ITimer timer2 = _target.Register(timer1);
+            TimerInfo timer2 = _target.Register(timer);
             
             Assert.IsNotNull(timer2);
-            Assert.AreEqual(timer1, timer2);
+            Assert.AreEqual(timer.Id, timer2.Id);
 
-            List<ITimer> timers = _target.GetTimers().ToList();
+            List<TimerInfo> timers = _target.GetTimers().ToList();
             Assert.AreEqual(1, timers.Count);
         }
 
@@ -101,7 +104,7 @@ namespace Chronos.Timer.Tests.Core
         [TestMethod]
         public void GetTimer_TimerIsRegistered_ReturnsTimer()
         {
-            ITimer timer = _target.Register<MockTimer>(TimeSpan.FromSeconds(1), 1, () => { });
+            TimerInfo timer = _target.Register<MockTimer>(TimeSpan.FromSeconds(1), 1, () => { });
 
             Assert.IsNotNull(_target.GetTimer(timer.Id));
         }
@@ -109,14 +112,14 @@ namespace Chronos.Timer.Tests.Core
         [TestMethod]
         public void GetTimer_TimerIsNotRegistered_ReturnsNull()
         {
-            ITimer timer = _target.GetTimer(Guid.NewGuid());
+            TimerInfo timer = _target.GetTimer(Guid.NewGuid());
             Assert.IsNull(timer);
         }
 
         [TestMethod]
         public void ListTimers_NoTimers_ReturnsEmptyList()
         {
-            List<ITimer> timers = _target
+            List<TimerInfo> timers = _target
                 .GetTimers()
                 .ToList();
 
@@ -126,9 +129,9 @@ namespace Chronos.Timer.Tests.Core
         [TestMethod]
         public void ListTimers_ContainsSingleTimer_SingleElement()
         {
-            ITimer timer = _target.Register<MockTimer>(TimeSpan.FromSeconds(1), 1, () => { });
+            TimerInfo timer = _target.Register<MockTimer>(TimeSpan.FromSeconds(1), 1, () => { });
 
-            List<ITimer> timers = _target
+            List<TimerInfo> timers = _target
                 .GetTimers()
                 .ToList();
 
@@ -139,7 +142,7 @@ namespace Chronos.Timer.Tests.Core
         [TestMethod]
         public void RegisterUnregisterList_ReturnsExpectedTimers()
         {
-            List<ITimer> timers = new List<ITimer>();
+            List<TimerInfo> timers = new List<TimerInfo>();
 
             int totalTimers = 10;
 
@@ -153,7 +156,7 @@ namespace Chronos.Timer.Tests.Core
                 _target.Unregister(timers[i].Id);
             }
 
-            List<ITimer> runtimeTimers = _target.GetTimers().ToList();
+            List<TimerInfo> runtimeTimers = _target.GetTimers().ToList();
             
             Assert.AreEqual(totalTimers - totalTimers / 2, runtimeTimers.Count);
             


### PR DESCRIPTION
The ITimer interface exposes internal Initialize/Update functionality which users should not be able to interact with.
In order to hide away these functions, we're adding the TimerProxy!

The timer proxy enables users to interact with the underlying timer in a safe way and removes the possibility of undesired side-effects through manual updates.