### PR TITLE
Add unit tests for timer proxy

### DIFF
--- a/src/Core/TimerProxy/TimerProxy.cs
+++ b/src/Core/TimerProxy/TimerProxy.cs
@@ -40,7 +40,7 @@ namespace Chronos.Timer.Core
 
         public TimerProxy(ITimer timer)
         {
-            _timer = timer;
+            _timer = timer ?? throw new ArgumentNullException(nameof(timer));
         }
 
         /// <summary>

--- a/src/Mocks/MockTimer.cs
+++ b/src/Mocks/MockTimer.cs
@@ -17,7 +17,7 @@ namespace Chronos.Timer.Mocks
         public Action OnClear { get; set; }
         public Func<bool> OnIsPaused { get; set; } = () => false;
         public Action OnPause { get; set; }
-        public Action OnUnPause { get; set; }
+        public Action OnUnpause { get; set; }
         public Func<Task> OnUpdateAsync { get; set; }
         public Action OnInitialize { get; set; }
         #endregion
@@ -32,7 +32,7 @@ namespace Chronos.Timer.Mocks
             => OnPause?.Invoke();
 
         public void Unpause()
-            => OnUnPause?.Invoke();
+            => OnUnpause?.Invoke();
 
         public Task UpdateAsync()
             => OnUpdateAsync?.Invoke();
@@ -55,7 +55,7 @@ namespace Chronos.Timer.Mocks
                 OnInitialize = (Action)OnInitialize?.Clone(),
                 OnIsPaused = (Func<bool>)OnIsPaused?.Clone(),
                 OnPause = (Action)OnPause?.Clone(),
-                OnUnPause = (Action)OnUnPause?.Clone(),
+                OnUnpause = (Action)OnUnpause?.Clone(),
                 OnUpdateAsync = (Func<Task>)OnUpdateAsync?.Clone(),
             };
         }

--- a/tests/Core/Unit/TimerFactoryUnitTests.cs
+++ b/tests/Core/Unit/TimerFactoryUnitTests.cs
@@ -10,9 +10,15 @@ namespace Chronos.Timer.Tests.Core
     [TestClass]
     public class TimerFactoryUnitTests
     {
-        private readonly TimerFactory _target;
-        private readonly BasicTimerAction _timerTask;
+        private TimerFactory _target;
+        private BasicTimerAction _timerTask;
         public TimerFactoryUnitTests()
+        {
+
+        }
+        
+        [TestInitialize]
+        public void Initialize()
         {
             _target = new TimerFactory();
             _timerTask = new BasicTimerAction(() => { }, TimeSpan.FromSeconds(1), 1);

--- a/tests/Core/Unit/TimerProxyUnitTests.cs
+++ b/tests/Core/Unit/TimerProxyUnitTests.cs
@@ -1,0 +1,85 @@
+﻿using Chronos.Timer.Core;
+using Chronos.Timer.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace Chronos.Timer.Tests.Core
+{
+    [TestClass]
+    public class TimerProxyUnitTests
+    {
+
+        [TestMethod]
+        public void Constructor_NullTimer_ThrowsArgumentNullException()
+        {
+            Assert.ThrowsException<ArgumentNullException>(
+                () => new TimerProxy(null));
+        }
+
+        [TestMethod]
+        public void Properties_LeveragesTimerProperties()
+        {
+            Guid targetId = Guid.NewGuid();
+            TimeSpan targetTimeLeft = TimeSpan.FromSeconds(2);
+            TimeSpan targetTotalElapsedTime = TimeSpan.FromSeconds(4);
+
+            MockTimer mockTimer = new MockTimer
+            {
+                Id = targetId,
+                TimeLeft = targetTimeLeft,
+                TotalElapsedTime = targetTotalElapsedTime
+            };
+
+            TimerProxy target = new TimerProxy(mockTimer);
+            
+            Assert.AreEqual(target.Id, target.Id);
+            Assert.AreEqual(target.TimeLeft, targetTimeLeft);
+            Assert.AreEqual(target.TotalElapsedTime, targetTotalElapsedTime);
+        }
+
+        [TestMethod]
+        public void Clear_UnderlyingTimerClears()
+        {
+            bool clearedCalled = false;
+            MockTimer mockTimer = new MockTimer
+            {
+                OnClear = () => clearedCalled = true
+            };
+
+            TimerProxy target = new TimerProxy(mockTimer);
+            target.Clear();
+
+            Assert.IsTrue(clearedCalled);
+        }
+
+        [TestMethod]
+        public void Pause_UnderlyingTimerPauses()
+        {
+            bool pauseCalled = false;
+            MockTimer mockTimer = new MockTimer
+            {
+                OnPause = () => pauseCalled = true
+            };
+
+            TimerProxy target = new TimerProxy(mockTimer);
+            target.Pause();
+
+            Assert.IsTrue(pauseCalled);
+        }
+
+        [TestMethod]
+        public void Unpause_UnderlyingTimerUnpauses()
+        {
+            bool unpauseCalled = false;
+            MockTimer mockTimer = new MockTimer
+            {
+                OnUnpause = () => unpauseCalled = true
+            };
+
+            TimerProxy target = new TimerProxy(mockTimer);
+            target.Unpause();
+
+            Assert.IsTrue(unpauseCalled);
+        }
+    }
+}


### PR DESCRIPTION
Closing up on #31 with unit tests.

## Added
 - Unit tests for timer proxy
 - Null guard for null timer when creating a new timer proxy.

## Refactor
 - Moved initialization logic for TimerFactory unit tests from constructor to an initialization function